### PR TITLE
Update hostinfo.py

### DIFF
--- a/src/redial/hostinfo.py
+++ b/src/redial/hostinfo.py
@@ -57,12 +57,12 @@ class HostInfo:
     def get_ssh_copy_command(self, identity_file):
         c = "ssh-copy-id -i {} ".format(identity_file)
 
+        if self.port:
+            c = c + " -p " + self.port
+            
         if self.username:
             c = c + self.username + "@"
 
         c = c + self.ip
-
-        if self.port:
-            c = c + " -p " + self.port
 
         return c


### PR DESCRIPTION
## Description
Fix ssh-copy-id command, port then host

## Motivation and Context
In current version ssh-copy-id gives an error:
```
/usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/Users/username/.ssh/id_ed25519.pub"
/usr/bin/ssh-copy-id: ERROR: Too many arguments.  Expecting a target hostname, got:

Usage: /usr/bin/ssh-copy-id [-h|-?|-f|-n|-s] [-i [identity_file]] [-p port] [-F alternative ssh_config file] [[-o <ssh -o options>] ...] [user@]hostname
	-f: force mode -- copy keys without trying to check if they are already installed
	-n: dry run    -- no keys are actually copied
	-s: use sftp   -- use sftp instead of executing remote-commands. Can be useful if the remote only allows sftp
	-h|-?: print this help
```

## Types of changes
Small change to change place of port in command